### PR TITLE
Listen to all interfaces by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ Prometheus metrics exporter for BullMQ
 
 ```bash
 docker run -it -p 3000:3000 \
-  -e HOST=0.0.0.0 \
   -e REDIS_HOST=host.docker.internal \
   igrek8/bullmq-prometheus
 ```
 
 ## Environments
 
-- `HOST` - HTTP server host (default: 127.0.0.1)
+- `HOST` - HTTP server host (default: 0.0.0.0)
 - `PORT` - HTTP server port (default: 3000)
 - `PROM_PREFIX` - Prometheus metric prefix (default: bull)
 - `BULL_PREFIX` - BullMQ prefix (default: bull)

--- a/main.mjs
+++ b/main.mjs
@@ -2,7 +2,7 @@ import { once } from "events";
 import { Redis } from "ioredis";
 import fastify from "fastify";
 
-const HOST = process.env.HOST ?? "127.0.0.1";
+const HOST = process.env.HOST ?? "0.0.0.0";
 const PORT = Number.parseInt(process.env.PORT ?? 3000);
 const PROM_PREFIX = process.env.PROM_PREFIX ?? "bull";
 const BULL_PREFIX = process.env.BULL_PREFIX ?? "bull";


### PR DESCRIPTION
Using 127.0.0.1 for binding wouldn't allow to access the exporter running in a container. Using 0.0.0.0 solves this issue.