### PR TITLE
Added TLS support for Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ docker run -it -p 3000:3000 -e REDIS_HOST=host.docker.internal igrek8/bullmq-pro
 - `REDIS_PASSWORD` - Redis password
 - `REDIS_DB` - Redis databases (comma separated list of colon separated tuples `index:alias`) (default: `0:default`)
   - For example `0:staging,1:sandbox`, the alias will be used as a label
+- `REDIS_CA` - Redis CA certificate (base64 encoded CA certificate) (default: none)
+  - For example `cat ca.crt | base64`
 
 ## Endpoints
 

--- a/main.mjs
+++ b/main.mjs
@@ -11,6 +11,7 @@ const REDIS_PORT = Number.parseInt(process.env.REDIST_PORT ?? 6379);
 const REDIS_DB = process.env.REDIS_DB ?? "0:default";
 const REDIS_USERNAME = process.env.REDIS_USERNAME;
 const REDIS_PASSWORD = process.env.REDIS_PASSWORD;
+const REDIS_CA = process.env.REDIS_CA;
 
 const app = fastify({ logger: true });
 
@@ -33,6 +34,7 @@ const redis = new Redis({
   password: REDIS_PASSWORD,
   maxRetriesPerRequest: null,
   offlineQueue: false,
+  tls: REDIS_CA ? { ca: Buffer.from(REDIS_CA, "base64"), rejectUnauthorized: true } : undefined
 });
 
 app.get("/health", (_, res) => {


### PR DESCRIPTION
Hi,

Thanks for the package!
For our Redis instance we need to be able to provide a CA certificate so I added functionality for that.
Figured I would contribute it back to the main branch.