### PR TITLE
Add max age metric for active and waiting jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ docker run -it -p 3000:3000 -e REDIS_HOST=host.docker.internal igrek8/bullmq-pro
     - `delayed_total` - Number of delayed jobs
     - `failed_total` - Number of failed jobs
     - `completed_total` - Number of completed jobs (last 1 minute)
+    - `active_max_age_sec` - Max age of active jobs
+    - `wait_max_age_sec` - Max age of pending jobs
 - `/health` - Health endpoint
   - `HTTP 200` - Redis is available
   - `HTTP 503` - Redis is unavailable

--- a/main.mjs
+++ b/main.mjs
@@ -101,6 +101,8 @@ app.get("/metrics", async (_, res) => {
           jobs.map((job) => (new Date().getTime() - job.timestamp) / 1000).reduce((a, b) => Math.max(a, b), 0)
         );
 
+      await bullQueue.disconnect();
+
       const data = {
         [`${PROM_PREFIX}_active_total`]: active_total,
         [`${PROM_PREFIX}_wait_total`]: wait_total,


### PR DESCRIPTION
Thanks for creating this tool!

Adding two metrics that I needed in my project, the age of the oldest waiting job and age of oldest active job. 
Don't know if this fits into what you were planning on adding to the tool, or if i should keep it in my own fork.  

I could also make them disabled by default, and add an environment variable to enable them. 