### PR TITLE
Allow for plain TLS without CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ docker run -it -p 3000:3000 -e REDIS_HOST=host.docker.internal igrek8/bullmq-pro
 - `REDIS_PASSWORD` - Redis password
 - `REDIS_DB` - Redis databases (comma separated list of colon separated tuples `index:alias`) (default: `0:default`)
   - For example `0:staging,1:sandbox`, the alias will be used as a label
+- `USE_TLS` - Whether to use TLS (default: false)
 - `REDIS_CA` - Redis CA certificate (base64 encoded CA certificate) (default: none)
   - For example `cat ca.crt | base64`
 


### PR DESCRIPTION
Add a `USE_TLS` env var that will give a plain TLS conf without the need to specify a CA certificate.
Needed in Azure managed Redis.

see: https://github.com/redis/ioredis#tls-options

when USE_TLS=true and REDIS_CA is not set
```
const redis = new Redis({
  host: "redis.my-service.com",
  tls: {},
});
```

when REDIS_CA is set
```
const redis = new Redis({
  host: "redis.my-service.com",
  tls: {
    ca: Buffer.from(REDIS_CA, "base64"),
    rejectUnauthorized: true,
  },
});
```

cc: @igrek8 @ilkkao